### PR TITLE
Revert "Disallow shrinking threadpool size once started."

### DIFF
--- a/ProcessState.cpp
+++ b/ProcessState.cpp
@@ -308,9 +308,6 @@ void ProcessState::spawnPooledThread(bool isMain)
 }
 
 status_t ProcessState::setThreadPoolConfiguration(size_t maxThreads, bool callerJoinsPool) {
-    LOG_ALWAYS_FATAL_IF(mThreadPoolStarted && maxThreads < mMaxThreads,
-           "Binder threadpool cannot be shrunk after starting");
-
     // if the caller joins the pool, then there will be one thread which is impossible.
     LOG_ALWAYS_FATAL_IF(maxThreads == 0 && callerJoinsPool,
            "Binder threadpool must have a minimum of one thread if caller joins pool.");


### PR DESCRIPTION
 * Reason: Breaks camera stack on kona.

This reverts commit 8e047f7a626c782a02dc9e67dee2dbae35bc6956.

Change-Id: If5fc5711c57f1a26c06be42ae16c1f6871fd9f0c